### PR TITLE
attributes updates:

### DIFF
--- a/doc/attributes_h/index.rst
+++ b/doc/attributes_h/index.rst
@@ -14,72 +14,127 @@ Overview
     The term :term:`ECU` in this document refers to Embedded C Utilities, 
     the shorthand name for this project.
     
-Provides wrappers for compiler-specific attributes so they can be modularly used within
-application code. The benefits of using these wrappers can be seen below:
+Provides wrappers for compiler-specific attributes, allowing them to be 
+modularly used within application code.
 
-.. code-block:: c
+.. warning::
 
-    /*----------------------- file .c -----------------------*/
-    #include "ecu/attributes.h"
-
-    /* If toolchain ever changes only ECU_ATTRIBUTE_UNUSED define will need 
-    to be updated. Rest of application code using this define can remain the 
-    same. ECU attempts to automatically update these defines based on your 
-    toolchain. */
-    static int ECU_ATTRIBUTE_UNUSED var = 5;
+    Currently only GCC is supported. This module will treat all attributes as unsupported
+    when using any other compiler.
 
 
-.. code-block:: c
-
-    /*----------------------- file .c -----------------------*/
-
-    /* No wrapper is used so not modular. If a toolchain that does not support
-    this attribute is used, all directives like this will have to be manually
-    changed throughout the application code. If you want to have backwards compatibility
-    between toolchains, you would have to use #ifdefs at every attribute call. */
-    static int __attribute__((unused)) var = 5;
-
-
-.. warning:: 
-
-    At this time only GCC is supported for this module.
-
-
-What If My Toolchain Is Not Supported By This Module?
-=======================================================
-For all ``non-critical`` attributes, ECU will create an empty #define directive so your code
-will still compile. Definitions will NOT be provided for ``critical`` attributes, so you will get a 
-compilation error wherever they are used in the application.
-
-``Critical`` attributes are ones that effect code functionality. For example :ecudoxygen:`ECU_ATTRIBUTE_PACKED`, which 
-effects the memory layout of structs. 
-
-``Non-critical`` attributes are ones that do not effect code functionality. For example :ecudoxygen:`ECU_ATTRIBUTE_UNUSED`,
-which just suppresses unused warnings but does not change the code executable.
-
-.. code-block:: c
-
-    /*----------------------- file .c -----------------------*/
-    #include "ecu/attributes.h" /* Assume you are using an unsupported toolchain for this example. */
-
-    /* ECU_ATTRIBUTE_UNUSED is non-critical so it expands to nothing. This code
-    will still compile even if using an unsupported toolchain. */
-    static int ECU_ATTRIBUTE_UNUSED var = 5;
-
-    /* ECU_ATTRIBUTE_PACKED is critical to code's functionality so no definition 
-    is provided if using an unsupported toolchain. Code like this will NOT compile,
-    assuming a symbol with this exact name is not defined anywhere else. */
-    struct ECU_ATTRIBUTE_PACKED my_data
-    {
-        int x;
-        int y;
-        int z;
-    };
-
-
-API
+Theory
 =================================================
-.. toctree:: 
+
+Attribute Overview
+-------------------------------------------------
+An attribute is a compiler extension (not apart of the C standard) used to convey
+specific information. For example, this informs GCC that variable foo is potentially
+unused. Therefore unused warnings should not be emitted for it:
+
+.. code-block:: c
+
+    static int foo __attribute__((unused)) = 0;
+
+Attributes are unique to each compiler, making the example above unportable.
+Code blocks like the one above would have to be manually changed if 
+a different compiler that does not support the unused attribute is ever used.
+Unfortunately, a common solution is to riddle the code with #ifdefs in order to
+support both configurations:
+
+.. code-block:: c
+
+    #ifdef __GNUC__
+    static int foo __attribute__((unused)) = 0;
+    #else
+    static int foo = 0;
+    #endif
+
+This module offers a portable solution by providing wrapper definitions that expand
+differently depending on the target compiler being used:
+
+.. code-block:: c
+
+    static int foo ECU_ATTRIBUTE_UNUSED = 0;
+
+Critical vs Non-critical Attributes
+-------------------------------------------------
+This module groups attributes into two categorites: ``critical`` and ``non-critical``.
+
+- ``critical``: these attributes effect the functionality of the program. Critical 
+  attributes not supported by the target compiler are **not** defined in order to produce 
+  a compilation error via unresolved symbols:
+
+    .. code-block:: c
+
+        struct ECU_ATTRIBUTE_PACKED foo
+        {
+            char a;
+            int c;
+            char b;
+        };
+  
+  The packed attribute in the example above is critical because it changes the memory
+  layout of struct foo. The program expects foo to be packed and would be invalidated when 
+  using compilers that do not support this attribute. If supported, ECU_ATTRIBUTE_PACKED 
+  expands to the compiler-specific packed attribute and the program compiles. Otherwise ECU_ATTRIBUTE_PACKED 
+  is not defined and a compilation error arises due ECU_ATTRIBUTE_PACKED being an undefined symbol.
+
+- ``non-critical``: these attributes do not effect the functionality of the program. 
+  Empty definitions are created for non-critical attributes that are not supported 
+  by the target compiler, which allows the program to still compile:
+
+    .. code-block:: c
+
+        /* Expands to static int foo = 0; if attribute unsupported. */
+        static int foo ECU_ATTRIBUTE_UNUSED = 0;
+
+  The unused attribute in the example above does not effect the functionality of the program.
+  If supported, ECU_ATTRIBUTE_UNUSED expands to the compiler-specific unused attribute. 
+  Otherwise an empty definition is created and ECU_ATTRIBUTE_UNUSED expands to nothing, 
+  allowing the program to still compile.
+
+API 
+=================================================
+.. toctree::
     :maxdepth: 1
 
-    API </doxygen/html/attributes_8h>
+    attributes.h </doxygen/html/attributes_8h>
+
+Critical Attributes
+-------------------------------------------------
+
+ECU_ATTRIBUTE_PACKED
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+If attached to a variable, informs compiler it should have the smallest possible 
+alignment. If attached to a type definition, informs compiler the minimum required 
+memory should be used to represent the type:
+
+.. code-block:: c
+
+    struct ECU_ATTRIBUTE_PACKED foo
+    {
+        char a;
+        int c;
+        char b;
+    };
+
+ECU_ATTRIBUTE_SECTION()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Places symbol in user-specified program section:
+
+.. code-block:: c
+
+    uint32_t vector_table[] ECU_ATTRIBUTE_SECTION(".vectors") = {.....};
+
+Non-critical Attributes
+-------------------------------------------------
+
+ECU_ATTRIBUTE_UNUSED
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Informs compiler that type, variable, or function may be unused so it does 
+not emit an unused warning:
+
+.. code-block:: c
+
+    static int foo ECU_ATTRIBUTE_UNUSED = 0;

--- a/doc/utils_h/index.rst
+++ b/doc/utils_h/index.rst
@@ -118,7 +118,7 @@ with each step being fully explained below:
         struct user_node *me = (uint8_t *)next - X;
 
     The offset 'X' can be determined at compile-time using `offsetof() <https://en.cppreference.com/w/c/types/offsetof>`_.
-    offsetof() is mandated by the C standard since C99, so this is guaranteed to be 
+    offsetof() is mandated by the C standard since C89, so this is guaranteed to be 
     a portable solution. Substituting this value in for 'X' completes the first portion
     of the expression:
 

--- a/inc/ecu/attributes.h
+++ b/inc/ecu/attributes.h
@@ -16,56 +16,55 @@
 
 #if defined(ECU_DOXYGEN)
     /**
-     * @brief This attribute is assigned to a variable to tell the compiler that it
-     * may be unused.
-     * @details Variable(s) with this attribute will not produce unused warnings
-     * even if the unused warning flag is passed to the compiler.
-     *
-     * 1. Expands to this if compiling with GCC.
-     * @code{.c}
-     * #define ECU_ATTRIBUTE_UNUSED             __attribute__((unused))
-     * @endcode
-     *
-     * 2. If none of the previous options apply to your toolchain then you
-     * are using an unsupported compiler. Non-critical attribute so macro
-     * will expand to nothing in this case. Therefore any code using this macro
-     * will still compile.
-     * @code{.c}
-     * #define ECU_ATTRIBUTE_UNUSED
-     * @endcode
+     * @name Critical Attributes
+     * These attributes effect the functionality of the program. Critical attributes 
+     * not supported by the target compiler are NOT defined in order to create a 
+     * a compilation error (critical attributes used in the program create 
+     * unresolved symbols).
      */
-    #define ECU_ATTRIBUTE_UNUSED
-
+    /**@{*/
     /**
-     * @brief This attribute is assigned to enum, struct, or union types and
-     * tells the compiler to not produce any padding between members.
-     * @details
-     * 1. Expands to this if compiling with GCC.
-     * @code{.c}
-     * #define ECU_ATTRIBUTE_PACKED             __attribute__((packed))
-     * @endcode
-     *
-     * 2. If none of the previous options apply to your toolchain then you are
-     * using an unsupported compiler. Critical attribute so this macro will NOT be
-     * defined. Any code using this macro will produce a compilation error.
+     * @brief Critical attribute. If attached to a variable, informs compiler it should
+     * have the smallest possible alignment. If attached to a type definition, informs
+     * compiler the minimum required memory should be used to represent the type.
      */
     #define ECU_ATTRIBUTE_PACKED
-#else
-    #ifdef __GNUC__
-        /**
-         * @brief Compiling with GCC so expands to GCC unused attribute.
-         */
-        #define ECU_ATTRIBUTE_UNUSED __attribute__((unused))
 
-        /**
-         * @brief Compiling with GCC so expands to GCC packed attribute.
-         */
-        #define ECU_ATTRIBUTE_PACKED __attribute__((packed))
-    #else /* Unsupported compilers. Empty-define only non-critical attributes. */
-        /**
-         * @brief Using unsupported compiler so this macro expands to nothing
-         * since it is not critical to the code's functionality.
-         */
+    /**
+     * @brief Critical attribute. Places symbol in user-specified program section.
+     * 
+     * @param x_ Name of section. Must be string literal.
+     */
+    #define ECU_ATTRIBUTE_SECTION(x_)
+    /**@}*/
+
+    /**
+     * @name Non-critical Attributes
+     * These attributes do not effect the functionality of the program. Empty definitions
+     * are created for non-critical attributes that are not supported by the target
+     * compiler, which allows the program to still compile.
+     */
+    /**@{*/
+    /**
+     * @brief Non-critical attribute. Informs compiler that type, variable,
+     * or function may be unused so it does not emit an unused warning.
+     */
+    #define ECU_ATTRIBUTE_UNUSED
+    /**@}*/
+#else
+    #if defined(__GNUC__) && !defined(__STRICT_ANSI__) /* Compiling with GCC with extensions enabled (attributes are compiler extensions not supported in ISO C). */
+        #if __GNUC__ > 2 || (__GNUC__ == 2 && (__GNUC_MINOR__ > 95 || (__GNUC_MINOR__ == 95 && __GNUC_PATCHLEVEL__ > 2))) /* GCC >= v2.95.3. Oldest version in GCC docs. */
+            /// @brief Critical attribute. GCC __attribute__((packed)).
+            #define ECU_ATTRIBUTE_PACKED __attribute__((packed))
+
+            /// @brief Critical attribute. GCC __attribute__((section)).
+            #define ECU_ATTRIBUTE_SECTION(x_) __attribute__((section(x_)))
+
+            /// @brief Non-critical attribute. GCC __attribute__((unused)).    
+            #define ECU_ATTRIBUTE_UNUSED __attribute__((unused))
+        #endif
+    #else /* Unsupported compilers. Empty-define only for non-critical attributes. */
+        /// @brief Non-critical attribute. Empty definition since using unsupported compiler.   
         #define ECU_ATTRIBUTE_UNUSED
     #endif
 #endif /* ECU_DOXYGEN */


### PR DESCRIPTION
- Complete attributes module.

- Finish documentation.

- Added support for section attribute.

- Now defining GCC attributes only if GNU C (not ISO C) is used.

- Specify minimum version of GCC required for GCC attributes.

- Corrected mentions of offsetof being mandated since C99. It is C89.